### PR TITLE
Fixed datamatrix type parsing to the incorrect format

### DIFF
--- a/platforms/ios/Sources/NimbusPluginBarcodeScanner/BarcodeScannerViewController.swift
+++ b/platforms/ios/Sources/NimbusPluginBarcodeScanner/BarcodeScannerViewController.swift
@@ -13,7 +13,7 @@ public enum BarcodeType: String, Codable, CaseIterable {
     case code128
     case code39
     case code93
-    case dataMatrix
+    case dataMatrix = "datamatrix"
     case ean13
     case ean8
     case itf


### PR DESCRIPTION
`BarcodeType` DATA_MATRIX in typescript is set to be a string = `datamatrix` all lowercase.  The default rawValue of a Swift String enum is as the enum is written.  So we had the default setup in camel case `dataMatrix`.  The camel case enum style is the standard for Swift enums.  So we are just setting the string to not be the default.

To verify the bug you can try to `beginCapture` with the `datamatrix` type and it will not parse correctly into `BarcodeType`.