### PR TITLE
make sure the barcode result are sent back without extra encoding

### DIFF
--- a/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailure.kt
+++ b/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailure.kt
@@ -1,3 +1,17 @@
 package com.salesforce.barcodescannerplugin
 
-data class BarcodeScannerFailure(val code: BarcodeScannerFailureCode, val message: String? = null)
+import com.salesforce.nimbus.JSONSerializable
+import org.json.JSONObject
+
+/**
+ * Barcode scanner failure
+ */
+data class BarcodeScannerFailure(val code: BarcodeScannerFailureCode, val message: String? = null) :
+    JSONSerializable {
+
+    override fun stringify() =
+        JSONObject().apply {
+            put("code", code.stringify())
+            putOpt("message", message)
+        }.toString()
+}

--- a/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCode.kt
+++ b/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCode.kt
@@ -5,7 +5,7 @@ import com.salesforce.nimbus.JSONSerializable
 /**
  * the error code the barcode scan could possible through
  */
-enum class BarcodeScannerFailureCode(val idStr: String) : JSONSerializable {
+enum class BarcodeScannerFailureCode(val value: String) : JSONSerializable {
 
     /**
      * the user clicked the button to dismiss the scanner
@@ -38,5 +38,5 @@ enum class BarcodeScannerFailureCode(val idStr: String) : JSONSerializable {
      */
     BRIDGE_UNAVAILABLE("bridgeUnavailable");
 
-    override fun stringify() = idStr
+    override fun stringify() = value
 }

--- a/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCode.kt
+++ b/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCode.kt
@@ -1,9 +1,11 @@
 package com.salesforce.barcodescannerplugin
 
+import com.salesforce.nimbus.JSONSerializable
+
 /**
  * the error code the barcode scan could possible through
  */
-enum class BarcodeScannerFailureCode(val idStr: String) {
+enum class BarcodeScannerFailureCode(val idStr: String) : JSONSerializable {
 
     /**
      * the user clicked the button to dismiss the scanner
@@ -34,5 +36,7 @@ enum class BarcodeScannerFailureCode(val idStr: String) {
      * It could be delivered to hosting activity when recreated after
      * leaving the scanning activity, but not the webview
      */
-    BRIDGE_UNAVAILABLE("bridgeUnavailable"),
+    BRIDGE_UNAVAILABLE("bridgeUnavailable");
+
+    override fun stringify() = idStr
 }

--- a/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerResult.kt
+++ b/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerResult.kt
@@ -14,10 +14,8 @@ import org.json.JSONObject
 import java.net.URLEncoder
 
 data class BarcodeScannerResult(val type: BarcodeType, val value: String) : JSONSerializable {
-    override fun stringify(): String {
-        return JSONObject().apply {
-            put("type", type)
-            put("value", URLEncoder.encode(value, "utf-8"))
-        }.toString()
-    }
+    override fun stringify() = JSONObject().apply {
+        put("type", type)
+        put("value", value)
+    }.toString()
 }

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCodeTest.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCodeTest.kt
@@ -8,18 +8,15 @@
  */
 package com.salesforce.barcodescannerplugin
 
-import com.salesforce.barcodescannerplugin.BarcodeScannerFailureCode.*
 import org.junit.Assert
 import org.junit.Test
 
 class BarcodeScannerFailureCodeTest {
 
     @Test
-    fun `verify converting to json`() {
-        Assert.assertEquals("userDeniedPermission", USER_DENIED_PERMISSION.stringify())
-        Assert.assertEquals("userDisabledPermissions", USER_DISABLED_PERMISSION.stringify())
-        Assert.assertEquals("userDismissedScanner", USER_DISMISSED_SCANNER.stringify())
-        Assert.assertEquals("unknownReason", UNKNOWN_REASON.stringify())
-        Assert.assertEquals("bridgeUnavailable", BRIDGE_UNAVAILABLE.stringify())
+    fun `stringify returns value`() {
+        BarcodeScannerFailureCode.values().forEach {
+            Assert.assertEquals(it.value, it.stringify())
+        }
     }
 }

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCodeTest.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureCodeTest.kt
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright (c) 2020, Salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+package com.salesforce.barcodescannerplugin
+
+import com.salesforce.barcodescannerplugin.BarcodeScannerFailureCode.*
+import org.junit.Assert
+import org.junit.Test
+
+class BarcodeScannerFailureCodeTest {
+
+    @Test
+    fun `verify converting to json`() {
+        Assert.assertEquals("userDeniedPermission", USER_DENIED_PERMISSION.stringify())
+        Assert.assertEquals("userDisabledPermissions", USER_DISABLED_PERMISSION.stringify())
+        Assert.assertEquals("userDismissedScanner", USER_DISMISSED_SCANNER.stringify())
+        Assert.assertEquals("unknownReason", UNKNOWN_REASON.stringify())
+        Assert.assertEquals("bridgeUnavailable", BRIDGE_UNAVAILABLE.stringify())
+    }
+}

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureTest.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureTest.kt
@@ -11,17 +11,22 @@ package com.salesforce.barcodescannerplugin
 import com.salesforce.barcodescannerplugin.BarcodeScannerFailureCode.*
 import org.junit.Assert
 import org.junit.Test
+import java.util.*
 
 class BarcodeScannerFailureTest {
     @Test
     fun `verify converting to json string`() {
         val error = BarcodeScannerFailure(USER_DISMISSED_SCANNER).stringify()
-        Assert.assertEquals("{\"code\":\"userDismissedScanner\"}", error)
+        Assert.assertEquals("{\"code\":\"${USER_DISMISSED_SCANNER.value}\"}", error)
     }
 
     @Test
     fun `verify converting to json string with message`() {
-        val error = BarcodeScannerFailure(UNKNOWN_REASON, "message body").stringify()
-        Assert.assertEquals("{\"code\":\"unknownReason\",\"message\":\"message body\"}", error)
+        val messageBody = UUID.randomUUID().toString()
+        val error = BarcodeScannerFailure(UNKNOWN_REASON, messageBody).stringify()
+        Assert.assertEquals(
+            "{\"code\":\"${UNKNOWN_REASON.value}\",\"message\":\"$messageBody\"}",
+            error
+        )
     }
 }

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureTest.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerFailureTest.kt
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright (c) 2020, Salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+package com.salesforce.barcodescannerplugin
+
+import com.salesforce.barcodescannerplugin.BarcodeScannerFailureCode.*
+import org.junit.Assert
+import org.junit.Test
+
+class BarcodeScannerFailureTest {
+    @Test
+    fun `verify converting to json string`() {
+        val error = BarcodeScannerFailure(USER_DISMISSED_SCANNER).stringify()
+        Assert.assertEquals("{\"code\":\"userDismissedScanner\"}", error)
+    }
+
+    @Test
+    fun `verify converting to json string with message`() {
+        val error = BarcodeScannerFailure(UNKNOWN_REASON, "message body").stringify()
+        Assert.assertEquals("{\"code\":\"unknownReason\",\"message\":\"message body\"}", error)
+    }
+}

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerResultTests.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerResultTests.kt
@@ -9,15 +9,27 @@
 
 package com.salesforce.barcodescannerplugin
 
+import com.salesforce.barcodescannerplugin.BarcodeType.QR
+import com.salesforce.barcodescannerplugin.BarcodeType.UPCE
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.util.UUID
 
 class BarcodeScannerResultTests {
     @Test
     fun `stringify returns type and value`() {
-        val barcodeScannerResult = BarcodeScannerResult(BarcodeType.UPCE, UUID.randomUUID().toString())
-        val stringified = barcodeScannerResult.stringify()
-        assert(stringified.contains("\"type\":\"${barcodeScannerResult.type}\""))
-        assert(stringified.contains("\"value\":\"${barcodeScannerResult.value}\""))
+        val json =  BarcodeScannerResult(UPCE, "SimpleCode").stringify()
+        assertEquals(json,"""{"type":"UPCE","value":"SimpleCode"}""")
+    }
+
+    @Test
+    fun `stringify returns can handle xml QR code`() {
+        val json = BarcodeScannerResult(QR, """<a href="#">text</a>""").stringify()
+        assertEquals(json,"""{"type":"QR","value":"<a href=\"#\">text<\/a>"}""")
+    }
+
+    @Test
+    fun `stringify returns can handle json QR code`() {
+        val json = BarcodeScannerResult(QR, """{"a":1,"b":{"c":true}}}""").stringify()
+        assertEquals(json,"""{"type":"QR","value":"{\"a\":1,\"b\":{\"c\":true}}}"}""")
     }
 }

--- a/platforms/android/demoapp/src/main/assets/webview.html
+++ b/platforms/android/demoapp/src/main/assets/webview.html
@@ -31,14 +31,15 @@ let continuousScan = false;
 let scanResults = [];
 
 function setResult(value){
-    document.querySelector("#result").innerHTML = value;
+    document.querySelector("#result").innerText = value;
 }
 
 let barcodeScannerCallback =
     (barcode, error) => {
         console.log(barcode);
         if (barcode !== null) {
-            scanResults.push("type: " + barcode.type + " value: " + decodeURIComponent(barcode.value) + "<br>");
+            console.log(barcode.value);
+            scanResults.push(JSON.stringify(barcode) + "\n");
             setResult(scanResults.join(""));
             if (continuousScan){
                 setTimeout(function() { barcodeScanner.resumeCapture(barcodeScannerCallback);}, 500)
@@ -46,7 +47,7 @@ let barcodeScannerCallback =
                 stopScanning()
             }
         } if (error !== null) {
-            scanResults.push("error: " + error + "<br>")
+            scanResults.push("error: " + JSON.stringify(error) + "\n")
             setResult(scanResults.join(""));
         }
     };
@@ -54,7 +55,7 @@ let barcodeScannerCallback =
 if (typeof deviceInfoPlugin !== undefined && deviceInfoPlugin !== null){
     deviceInfoPlugin.getDeviceInfo().then( (deviceInfo) => {
         console.log(deviceInfo);
-        setResult("<p>Click Scan Barcode to begin. Current version: " + deviceInfo.appVersion + "</p>");
+        setResult("Click Scan Barcode to begin. Current version: " + deviceInfo.appVersion );
     });
 }
 
@@ -75,7 +76,5 @@ function stopScanning() {
         barcodeScanner.endCapture()
     }
 }
-
-
 </script>
 </html>


### PR DESCRIPTION
1. make sure complex qr code is sent back property by skip the no-needed encoding
2. make sure failure code is sent back as proper json object.