### PR TITLE
chore: Point to main branch of Nimbus

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "Nimbus",
         "repositoryURL": "https://github.com/salesforce/nimbus",
         "state": {
-          "branch": "master",
-          "revision": "21d3cc7ef4bac43e07cf00002fe5f2bd706397dd",
+          "branch": "main",
+          "revision": "86b42d56e5091bf30b647d23e395f72d06da671c",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["NimbusPluginBarcodeScanner"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/salesforce/nimbus", .branch("master"))
+        .package(url: "https://github.com/salesforce/nimbus", .branch("main"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Nimbus Core doesn't use `master` anymore.