### PR TITLE
fix: Empty barcode type array will include all barcode types 

### DIFF
--- a/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerOptions.kt
+++ b/platforms/android/barcodescanner/src/main/java/com/salesforce/barcodescannerplugin/BarcodeScannerOptions.kt
@@ -20,9 +20,13 @@ class BarcodeScannerOptions(val barcodeTypes: List<BarcodeType> = listOf()) : Se
             return try {
                 val options = JSONObject(barcodeScannerOptions)
                 val barcodeTypes = options.getJSONArray("barcodeTypes")
-                val convertedTypes = mutableListOf<BarcodeType>()
-                for (i in 0 until barcodeTypes.length()) {
-                    convertedTypes.add(BarcodeType.valueOf(barcodeTypes.getString(i).toUpperCase()))
+                var convertedTypes = mutableListOf<BarcodeType>()
+                if (barcodeTypes.length() > 0) {
+                    for (i in 0 until barcodeTypes.length()) {
+                        convertedTypes.add(BarcodeType.valueOf(barcodeTypes.getString(i).toUpperCase()))
+                    }
+                } else {
+                    convertedTypes = enumValues<BarcodeType>().toMutableList()
                 }
                 BarcodeScannerOptions(convertedTypes)
             } catch (e: Exception) {

--- a/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerOptionsTests.kt
+++ b/platforms/android/barcodescanner/src/test/java/com/salesforce/barcodescannerplugin/BarcodeScannerOptionsTests.kt
@@ -44,4 +44,15 @@ class BarcodeScannerOptionsTests {
         val barcodeScannerOptions = BarcodeScannerOptions()
         assert(barcodeScannerOptions.barcodeTypes.count() == 0)
     }
+
+    @Test
+    fun `convert json to barcodeScannerOptions with all barcode types when the input array is empty`() {
+        val originalOptions = """
+            {'barcodeTypes': 
+                []
+            }
+        """.trimIndent()
+        val barcodeScannerOptions = BarcodeScannerOptions.fromJSON(originalOptions)
+        assert(barcodeScannerOptions.barcodeTypes.count() == enumValues<BarcodeType>().count())
+    }
 }


### PR DESCRIPTION
The changed behavior will match iOS and as well as what the mobile capabilities documentation writes about the empty array.