### PR TITLE
Remove android publishing plugin

### DIFF
--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -15,7 +15,6 @@ buildscript {
     dependencies {
         classpath('com.android.tools.build:gradle:4.1.0')
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-        classpath("com.github.dcendents:android-maven-gradle-plugin:2.1")
         classpath("com.google.gms:google-services:4.3.3") // google-services plugin
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         classpath("org.jetbrains.kotlin:kotlin-serialization:$kotlin_version")

--- a/platforms/android/gradle/publishing.gradle
+++ b/platforms/android/gradle/publishing.gradle
@@ -1,4 +1,3 @@
-apply plugin: "com.github.dcendents.android-maven"
 apply plugin: "com.jfrog.bintray"
 
 task sourcesJar(type: Jar) {
@@ -61,24 +60,24 @@ task patchAndTag {
 }
 
 createTag.mustRunAfter bumpPatch
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging POM_PACKAGING
-                name project.name
-                url POM_URL
-                licenses {
-                    license {
-                        name POM_LICENSE_NAME
-                        url POM_LICENSE_URL
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                pom {
+                    url = POM_URL
+                    licenses {
+                        license {
+                            name = POM_LICENSE_NAME
+                            url = POM_LICENSE_URL
+                        }
                     }
-                }
-                scm {
-                    connection POM_SCM_CONNECTION
-                    developerConnection POM_SCM_DEV_CONNECTION
-                    url POM_SCM_URL
+                    scm {
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                        url = POM_SCM_URL
+                    }
                 }
             }
         }


### PR DESCRIPTION
[This plugin](https://github.com/dcendents/android-maven-gradle-plugin) is deprecated and marked read-only in github now.
This is now built-in functionality to the Android Gradle Plugin. See https://developer.android.com/studio/build/maven-publish-plugin